### PR TITLE
Fixed Readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ myadc = SAR(bit, ncomp, ndac, nsamp, radix)
 norm_input, center, maxbin = normalize_input(adcin)
 
 # Run ADC
-adcout=myadc.sarloop(norm_input)
+adcout=myadc.forward(norm_input)
 
 # Rescale ADC output to original
 adcout, _ , _ = normalize_input(adcout)


### PR DESCRIPTION
Readme example was using sarloop function, which no longer exists. Switched to using the forward function.